### PR TITLE
bump to version 0.19.2

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -2,7 +2,7 @@
 set -e
 
 : ${GIT:=https://github.com/google/cadvisor.git}
-: ${COMMIT:=0.16.0}
+: ${COMMIT:=v0.19.2}
 
 cd $(dirname $0)/..
 


### PR DESCRIPTION
cadvisor started tagging with a 'v' prefix.
